### PR TITLE
add error handling for embed.addFields to catch `CombinedPropertyError`

### DIFF
--- a/bot/features/earthquake/earthquake.ts
+++ b/bot/features/earthquake/earthquake.ts
@@ -366,7 +366,7 @@ const resolveJMAQuake = async (response: JMAQuake): Promise<void> => {
               logError(
                 e,
                 `earthquake#${resolveJMAQuake.name}:`,
-                `failed to add field that ${{ pref, points: JSON.stringify(points) }}`,
+                `failed to add field that ${JSON.stringify({ pref, points })}`,
               );
               continue;
             }

--- a/bot/features/earthquake/earthquake.ts
+++ b/bot/features/earthquake/earthquake.ts
@@ -357,7 +357,21 @@ const resolveJMAQuake = async (response: JMAQuake): Promise<void> => {
           .setColor(getColorsOfIntensity(intensity));
 
         for (const [pref, points] of groupedByPrefPoints) {
-          embed.addFields({ name: pref, value: points.join('、') });
+          try {
+            // it may occurs `CombinedPropertyError` in @sapphire/shapeshift
+            embed.addFields({ name: pref, value: points.join('、') });
+          }
+          catch (e) {
+            if (e instanceof Error && e.name === 'CombinedPropertyError') {
+              logError(
+                e,
+                `earthquake#${resolveJMAQuake.name}:`,
+                `failed to add field that ${{ pref, points: JSON.stringify(points) }}`,
+              );
+              continue;
+            }
+            throw e;
+          }
         }
 
         try {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 地震情報機能の安定性を向上しました。データ処理エラーが発生した場合でも、機能全体が停止せず、処理を継続するようになりました。これにより、部分的なデータの問題が全体のサービス提供に影響しないようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->